### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/aiw-devops/41051c98-5423-4a4c-88d7-a81ca6e22445/d367870d-4021-4bc6-95ff-e065725764de/_apis/work/boardbadge/4cdb90f9-c9dd-4a82-b2bd-5a859f2d7226)](https://dev.azure.com/aiw-devops/41051c98-5423-4a4c-88d7-a81ca6e22445/_boards/board/t/d367870d-4021-4bc6-95ff-e065725764de/Microsoft.RequirementCategory)
 # Contoso Traders
 
 ![Logo](./docs/images/logo-1280x640.png)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2523](https://dev.azure.com/aiw-devops/41051c98-5423-4a4c-88d7-a81ca6e22445/_workitems/edit/2523). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.